### PR TITLE
Terraform hotfix

### DIFF
--- a/04/src/main.tf
+++ b/04/src/main.tf
@@ -6,7 +6,7 @@ module "vpc_dev" {
 }
 
 module "marketing-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=282797c08889fb2ab78c1ac69fcd435453df860d"
   env_name       = "develop"
   network_id     = module.vpc_dev.vpc_network.id
   subnet_zones   = [var.default_zone]
@@ -14,7 +14,6 @@ module "marketing-vm" {
   instance_name  = "web"
   instance_count = 1
   image_family   = var.image_family
-  public_ip      = true
   labels = {
     project = "marketing"
   }
@@ -25,7 +24,7 @@ module "marketing-vm" {
 }
 
 module "analytics-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=282797c08889fb2ab78c1ac69fcd435453df860d"
   env_name       = "stage"
   network_id     = module.vpc_dev.vpc_network.id
   subnet_zones   = [var.default_zone]
@@ -33,7 +32,6 @@ module "analytics-vm" {
   instance_name  = "web-stage"
   instance_count = 1
   image_family   = var.image_family
-  public_ip      = true
   labels = {
     project = "analytics"
   }

--- a/04/src/providers.tf
+++ b/04/src/providers.tf
@@ -1,7 +1,14 @@
+
 terraform {
+  required_version = ">=1.5"
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = ">=0.13"
+    }
+    template={
+      source = "hashicorp/template"
+      version = ">=2.1"
     }
   }
   backend "s3" {
@@ -13,10 +20,9 @@ terraform {
     skip_region_validation = true
     skip_credentials_validation = true
 
-    dynamodb_endpoint = "https://docapi.serverless.yandexcloud.net/ru-central1/b1gjmftgjegm4ag26bp3/etnqkmb3bcvegntd$    dynamodb_table = "tfstate-lock"
-
+    dynamodb_endpoint = "https://docapi.serverless.yandexcloud.net/ru-central1/b1gjmftgjegm4ag26bp3/etnqkmb3bcvegntd1pls"
+    dynamodb_table = "tfstate-lock"
   }
-  required_version = ">=0.13"
 }
 
 provider "yandex" {

--- a/04/src/vpc_dev/outputs.tf
+++ b/04/src/vpc_dev/outputs.tf
@@ -1,0 +1,8 @@
+output "vpc_network"{
+  value       = yandex_vpc_network.network
+  description = "Yandex vpc network"
+}
+output "vpc_subnet"{
+  value       = yandex_vpc_subnet.subnet
+  description = "Yandex vpc subnet"
+}

--- a/04/src/vpc_dev/variables.tf
+++ b/04/src/vpc_dev/variables.tf
@@ -1,0 +1,14 @@
+variable "env_name" {
+  type        = string
+  description = "VPC network&subnet name"
+}
+
+variable "cidr_block"{
+  type        = list(string)
+  default     = ["10.0.1.0/24"]
+}
+
+variable "zone"{
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
TFLint
<details>
  <summary>tflint</summary>

```bash
[root@terraform01 src]# tflint
2 issue(s) found:

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 9:
   9:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_module_pinned_source.md

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref:main" is not pinned (terraform_module_pinned_source)

  on main.tf line 28:
  28:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref:main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_module_pinned_source.md
```
</details>

Checkov

<details>
  <summary>checkov</summary>

```bash
[root@terraform01 src]# docker run --rm --tty --volume $(pwd):/tf --workdir /tf bridgecrew/checkov \
> --download-external-modules true --directory /tf


       _               _
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V /
  \___|_| |_|\___|\___|_|\_\___/ \_/

By Prisma Cloud | version: 3.2.38
Update available 3.2.38 -> 3.2.39
Run pip3 install -U checkov to update


terraform scan results:

Passed checks: 2, Failed checks: 6, Skipped checks: 0

Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/HEAD/main.tf:24-73
        Calling File: /main.tf:27-45
Check: CKV_YC_4: "Ensure compute instance does not have serial console enabled."
        PASSED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/HEAD/main.tf:24-73
        Calling File: /main.tf:8-25
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        FAILED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/HEAD/main.tf:24-73
        Calling File: /main.tf:27-45

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        FAILED for resource: module.analytics-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/HEAD/main.tf:24-73
        Calling File: /main.tf:27-45

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_2: "Ensure compute instance does not have public IP."
        FAILED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/HEAD/main.tf:24-73
        Calling File: /main.tf:8-25

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_YC_11: "Ensure security group is assigned to network interface."
        FAILED for resource: module.marketing-vm.yandex_compute_instance.vm[0]
        File: /.external_modules/github.com/udjin10/yandex_compute_instance/HEAD/main.tf:24-73
        Calling File: /main.tf:8-25

                Code lines for this resource are too many. Please use IDE of your choice to review the file.
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        FAILED for resource: marketing-vm
        File: /main.tf:8-25
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision

                8  | module "marketing-vm" {
                9  |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git"
                10 |   env_name       = "develop"
                11 |   network_id     = module.vpc_dev.vpc_network.id
                12 |   subnet_zones   = [var.default_zone]
                13 |   subnet_ids     = [module.vpc_dev.vpc_subnet.id]
                14 |   instance_name  = "web"
                15 |   instance_count = 1
                16 |   image_family   = var.image_family
                17 |   public_ip      = true
                18 |   labels = {
                19 |     project = "marketing"
                20 |   }
                21 |   metadata = {
                22 |     user-data          = data.template_file.cloudinit.rendered
                23 |     serial-port-enable = 1
                24 |   }
                25 | }

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        FAILED for resource: analytics-vm
        File: /main.tf:27-45
        Guide: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/supply-chain-policies/terraform-policies/ensure-terraform-module-sources-use-git-url-with-commit-hash-revision

                27 | module "analytics-vm" {
                28 |   source         = "git::https://github.com/udjin10/yandex_compute_instance.git"
                29 |   env_name       = "stage"
                30 |   network_id     = module.vpc_dev.vpc_network.id
                31 |   subnet_zones   = [var.default_zone]
                32 |   subnet_ids     = [module.vpc_dev.vpc_subnet.id]
                33 |   instance_name  = "web-stage"
                34 |   instance_count = 1
                35 |   image_family   = var.image_family
                36 |   public_ip      = true
                37 |   labels = {
                38 |     project = "analytics"
                39 |   }
                40 |   metadata = {
                41 |     user-data          = data.template_file.cloudinit.rendered
                42 |     serial-port-enable = 1
                43 |   }
                44 |
                45 | }


```
</details>
  

Terraform plan

<details>
  <summary>terraform plan</summary>

```bash
[root@terraform01 src]# terraform plan
data.template_file.cloudinit: Reading...
data.template_file.cloudinit: Read complete after 0s [id=7f522742d8c23602f05628709151aa2824db66252cc90bcb71873d9397d99124]
module.marketing-vm.data.yandex_compute_image.my_image: Reading...
module.analytics-vm.data.yandex_compute_image.my_image: Reading...
module.vpc_dev.yandex_vpc_network.network: Refreshing state... [id=enpgrqlk0ngjbmlsh97k]
module.marketing-vm.data.yandex_compute_image.my_image: Read complete after 0s [id=fd8dmgc8d3slc0q9pjvv]
module.analytics-vm.data.yandex_compute_image.my_image: Read complete after 0s [id=fd8dmgc8d3slc0q9pjvv]
module.vpc_dev.yandex_vpc_subnet.subnet: Refreshing state... [id=e9bd4jvgnsrrf6aq4cn0]
module.marketing-vm.yandex_compute_instance.vm[0]: Refreshing state... [id=fhmd24qk5o19j6lvtbmj]
module.analytics-vm.yandex_compute_instance.vm[0]: Refreshing state... [id=fhmk94jj15v06s46dke7]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply" which may have
affected this plan:

  # module.vpc_dev.yandex_vpc_network.network has changed
  ~ resource "yandex_vpc_network" "network" {
        id                        = "enpgrqlk0ngjbmlsh97k"
        name                      = "develop"
      ~ subnet_ids                = [
          + "e9bd4jvgnsrrf6aq4cn0",
        ]
        # (4 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using
ignore_changes, the following plan may include actions to undo or respond to these changes.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with
the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.analytics-vm.yandex_compute_instance.vm[0] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhmk94jj15v06s46dke7"
        name                      = "stage-web-stage-0"
        # (12 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
            # (9 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

  # module.marketing-vm.yandex_compute_instance.vm[0] will be updated in-place
  ~ resource "yandex_compute_instance" "vm" {
        id                        = "fhmd24qk5o19j6lvtbmj"
        name                      = "develop-web-0"
        # (12 unchanged attributes hidden)

      ~ network_interface {
          ~ nat                = true -> false
            # (9 unchanged attributes hidden)
        }

        # (5 unchanged blocks hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions
if you run "terraform apply" now.
```
</details>